### PR TITLE
Dodano członka nadzwyczajnego i uporządkowano podpunkty

### DIFF
--- a/Statut_HSP.tex
+++ b/Statut_HSP.tex
@@ -187,9 +187,9 @@ Członkowie zwyczajni mają obowiązek:
 \item
   Członek nadzwyczajny musi mieć obowiązek przestrzegania statutu i uchwał władz stowarzyszenia.
 \item 
-  Członek nadzwyczajny musi nie posiadać biernego oraz czynnego prawa wyborczego.
+  Członek nadzwyczajny nie może posiadać biernego oraz czynnego prawa wyborczego.
 \item
-  Członek zwykły może w każdym momencie zostać członkiem nadzwyczajnym informując w formie pisemnej zarząd.
+  Członek nadzwyczajny może stać się członkiem zwyczajnym po zatwierdzeniu przez zarząd.
 \end{enumerate}
 
 \myparagraph{§ 12.W.1}


### PR DESCRIPTION
CHANGELIST:
- Członek Nadzwyczajny został dodany
- Członek Wspierający musi płacić składki
- Członek Zwykły nadal może na swój wniosek przenieść się do członka Wspierającego (ale już nie ma po co?)
- Numeracja została zmodyfikowana, by nie doprowadzić do konfliktu numerków